### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+   - amd64
+   - ppc64le
 language: php
 php:
   - '5.4'
@@ -14,12 +17,15 @@ cache:
 matrix:
   fast_finish: true
   allow_failures:
+  - php: '5.4'    # not supported on Xenial
+  - php: '5.5'    # not supported on Xenial
   - php: nightly
 
 branches:
   only:
   - master
   - /^v\d/
+  - ppc64le
 
 before_script:
 - ./test/setup_vendor.sh


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/icingaweb2-module-eventdb/builds/191640244 . I believe it is ready for the final review and merge.
Please have a look on it.

Note: php:5.4 &5.5 putted in allowed-failures part as there is no support for amd64 and ppc64 for these two versions.

Thanks !!